### PR TITLE
Add python3-gi-cairo as a dependency for Debian/Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.5.0
 
 Package: plots
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, gir1.2-gtk-3.0, fonts-lmodern
+Depends: ${python3:Depends}, ${misc:Depends}, python3-gi-cairo, gir1.2-gtk-3.0, fonts-lmodern
 Description: Simple graph plotting
  Plots makes it easy to visualise mathematical formulae. In addition to basic arithmetic operations, it supports trigonometric, hyperbolic, exponential and logarithmic functions, as well as arbitrary sums and products.
  .


### PR DESCRIPTION
I think the .deb/PPA is missing a dependency on [python3-gi-cairo](https://packages.ubuntu.com/focal/python3-gi-cairo).

If I manually install that package, plots works well (:tada:), but without it I get this error on startup, and I can't enter formulae.

```
$ plots
TypeError: Couldn't find foreign struct converter for 'cairo.Context'
```
