### PR TITLE
Add Education to .desktop file

### DIFF
--- a/res/com.github.alexhuntley.Plots.desktop
+++ b/res/com.github.alexhuntley.Plots.desktop
@@ -3,4 +3,4 @@ Name=Plots
 Exec=plots
 Type=Application
 Icon=com.github.alexhuntley.Plots
-Categories=GNOME;GTK;Science;Math
+Categories=GNOME;GTK;Science;Math;Education

--- a/snap/gui/plots.desktop
+++ b/snap/gui/plots.desktop
@@ -3,4 +3,4 @@ Name=Plots
 Exec=plots
 Type=Application
 Icon=${SNAP}/meta/gui/plots.svg
-Categories=GNOME;GTK;Science;Math
+Categories=GNOME;GTK;Science;Math;Education


### PR DESCRIPTION
Otherwise, it showed up in `Others` category in MATE and Cinnamon (they have a Education category, but not Math or Science).

I have verified that this edited .desktop file fixes it.