### PR TITLE
flatpak: bump runtime version and add missing help pages translations

### DIFF
--- a/com.github.alexhuntley.Plots.json
+++ b/com.github.alexhuntley.Plots.json
@@ -39,7 +39,14 @@
         "install -D res/com.github.alexhuntley.Plots.svg -t /app/share/icons/hicolor/scalable/apps/",
         "install -D res/com.github.alexhuntley.Plots-symbolic.svg -t /app/share/icons/hicolor/symbolic/apps/",
         "install -D -t /app/share/help/C/plots/ help/C/*",
-        "install -D -t /app/share/help/fr/plots/ help/fr/*"
+        "install -D -t /app/share/help/es/plots/ help/es/*",
+        "install -D -t /app/share/help/fa/plots/ help/fa/*",
+        "install -D -t /app/share/help/fr/plots/ help/fr/*",
+        "install -D -t /app/share/help/hr/plots/ help/hr/*",
+        "install -D -t /app/share/help/it/plots/ help/it/*",
+        "install -D -t /app/share/help/nb_NO/plots/ help/nb_NO/*",
+        "install -D -t /app/share/help/nl/plots/ help/nl/*",
+        "install -D -t /app/share/help/pt_BR/plots/ help/pt_BR/*"
       ],
       "sources": [
         {

--- a/com.github.alexhuntley.Plots.json
+++ b/com.github.alexhuntley.Plots.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.alexhuntley.Plots",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "40",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "plots",
   "finish-args": [


### PR DESCRIPTION
I can open a PR in the Flathub repository to make these changes as well, if you want.