### PR TITLE
Make ² and ³ shortcuts for ^2 and ^3

### DIFF
--- a/plots/formula.py
+++ b/plots/formula.py
@@ -139,9 +139,9 @@ class Editor(Gtk.DrawingArea):
                 return True
             else:
                 return False
-        if char in "²³":
+        if char in "⁰¹²³⁴⁵⁶⁷⁸⁹":
             self.cursor.insert_superscript_subscript(superscript=True)
-            translation = str.maketrans("²³", "23")
+            translation = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹", "0123456789")
             self.cursor.insert(Atom(char.translate(translation)))
             self.cursor.handle_movement(Direction(Gdk.KEY_Right), select=False) # reset cursor level
             self.queue_draw()

--- a/plots/formula.py
+++ b/plots/formula.py
@@ -139,6 +139,13 @@ class Editor(Gtk.DrawingArea):
                 return True
             else:
                 return False
+        if char in "²³":
+            self.cursor.insert_superscript_subscript(superscript=True)
+            translation = str.maketrans("²³", "23")
+            self.cursor.insert(Atom(char.translate(translation)))
+            self.queue_draw()
+            self.emit("edit")
+            return
         if char.isalnum():
             self.cursor.insert(Atom(char))
             self.queue_draw()

--- a/plots/formula.py
+++ b/plots/formula.py
@@ -143,6 +143,7 @@ class Editor(Gtk.DrawingArea):
             self.cursor.insert_superscript_subscript(superscript=True)
             translation = str.maketrans("²³", "23")
             self.cursor.insert(Atom(char.translate(translation)))
+            self.cursor.handle_movement(Direction(Gdk.KEY_Right), select=False) # reset cursor level
             self.queue_draw()
             self.emit("edit")
             return


### PR DESCRIPTION
"²" and "³" are handled as alphanumeric characters instead of squaring/cubing the current formula.