### PR TITLE
Improve conversion of equations from/to LaTeX

### DIFF
--- a/plots/elements/atom.py
+++ b/plots/elements/atom.py
@@ -61,7 +61,7 @@ class BinaryOperatorAtom(BaseAtom):
         if self.name == "−":
             return "-"
         elif self.name == "×":
-            return "\\times"
+            return "\\times "
         else:
             return self.name
 

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -98,7 +98,7 @@ GREEK : "α".."ω" | "Α".."Ω"
 SYMBOL : "." | "!"
 atom : LETTER | GREEK | DIGIT | SYMBOL
 
-TIMES : "\\times"
+TIMES : "\\times" | "*"
 binary : TIMES -> times
        | "+" -> plus
        | "-" -> minus

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -111,27 +111,28 @@ binary : TIMES -> times
 OPNAME : LETTER+
 operator : "\\operatorname{" OPNAME "}"
 
-atomaslist.0 : atom -> list
+atomaslist.-1 : atom -> list
+?argument : blist | atomaslist
 
-subscriptsuperscript.2 : "_" (blist|atomaslist) "^" (blist|atomaslist)
-superscriptsubscript.2 : "^" (blist|atomaslist) "_" (blist|atomaslist)
-supersub : "_" (blist|atomaslist) -> subscript
-         | "^" (blist|atomaslist) -> superscript
+subscriptsuperscript.2 : "_" argument "^" argument
+superscriptsubscript.2 : "^" argument "_" argument
+supersub : "_" argument -> subscript
+         | "^" argument -> superscript
 
-frac.10 : "\\frac" blist blist
+frac.10 : "\\frac" argument argument
 
-radical : "\\sqrt" blist -> sqrt
-        | "\\sqrt" "[" list "]" blist -> nthroot
+radical : "\\sqrt" argument -> sqrt
+        | "\\sqrt" "[" list "]" argument -> nthroot
 
-abs : "\\abs" blist
-floor : "\\floor" blist
-ceil : "\\ceil" blist
+abs : "\\abs" argument
+floor : "\\floor" argument
+ceil : "\\ceil" argument
 
 PAREN : "(" | "[" | "\\{" | ")" | "]" | "\\}"
 paren : PAREN
 
-sum : "\\sum" "_" blist "^" blist
-prod : "\\prod" "_" blist "^" blist
+sum : "\\sum" "_" argument "^" argument
+prod : "\\prod" "_" argument "^" argument
 
 %import common.LETTER
 %import common.DIGIT

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -125,6 +125,7 @@ radical : "\\sqrt" argument -> sqrt
         | "\\sqrt" "[" list "]" argument -> nthroot
 
 abs : "\\abs" argument
+    | "\\left"? "|" list "\\right"? "|"
 floor : "\\floor" argument
       | "\\lfloor" list "\\rfloor"
 ceil : "\\ceil" argument

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -126,7 +126,9 @@ radical : "\\sqrt" argument -> sqrt
 
 abs : "\\abs" argument
 floor : "\\floor" argument
+      | "\\lfloor" list "\\rfloor"
 ceil : "\\ceil" argument
+     | "\\lceil" list "\\rceil"
 
 PAREN : "(" | "[" | "\\{" | ")" | "]" | "\\}"
 paren : PAREN

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -108,8 +108,8 @@ OPNAME : LETTER+
 operator : "\\operatorname{" OPNAME "}"
 
 subscriptsuperscript.2 : "_" blist "^" blist
-supersub : "_" (blist|atom) -> subscript
-         | "^" (blist|atom) -> superscript
+supersub : "_" blist -> subscript
+         | "^" blist -> superscript
 
 frac.10 : "\\frac" blist blist
 

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -108,8 +108,8 @@ OPNAME : LETTER+
 operator : "\\operatorname{" OPNAME "}"
 
 subscriptsuperscript.2 : "_" blist "^" blist
-supersub : "_" blist -> subscript
-         | "^" blist -> superscript
+supersub : "_" (blist|atom) -> subscript
+         | "^" (blist|atom) -> superscript
 
 frac.10 : "\\frac" blist blist
 

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -131,7 +131,7 @@ floor : "\\floor" argument
 ceil : "\\ceil" argument
      | "\\left"? "\\lceil" list "\\right"? "\\rceil"
 
-PAREN : ("(" | "[" | "\\{" | ")" | "]" | "\\}")
+PAREN : "(" | "[" | "\\{" | ")" | "]" | "\\}"
 paren : ("\\left"|"\\right")? PAREN
 
 sum : "\\sum" "_" argument "^" argument

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -50,6 +50,9 @@ class LatexTransformer(Transformer):
     def subscriptsuperscript(self, items):
         return elements.SuperscriptSubscript(subscript=items[0], exponent=items[1])
 
+    def superscriptsubscript(self, items):
+        return elements.SuperscriptSubscript(exponent=items[0], subscript=items[1])
+
     def frac(self, items):
         return elements.Frac(numerator=items[0], denominator=items[1])
 
@@ -93,6 +96,7 @@ list : element*
          | sum
          | prod
          | subscriptsuperscript
+         | superscriptsubscript
 
 GREEK : "α".."ω" | "Α".."Ω"
 SYMBOL : "." | "!"
@@ -107,9 +111,12 @@ binary : TIMES -> times
 OPNAME : LETTER+
 operator : "\\operatorname{" OPNAME "}"
 
-subscriptsuperscript.2 : "_" blist "^" blist
-supersub : "_" blist -> subscript
-         | "^" blist -> superscript
+atomaslist.0 : atom -> list
+
+subscriptsuperscript.2 : "_" (blist|atomaslist) "^" (blist|atomaslist)
+superscriptsubscript.2 : "^" (blist|atomaslist) "_" (blist|atomaslist)
+supersub : "_" (blist|atomaslist) -> subscript
+         | "^" (blist|atomaslist) -> superscript
 
 frac.10 : "\\frac" blist blist
 

--- a/plots/parser.py
+++ b/plots/parser.py
@@ -127,12 +127,12 @@ radical : "\\sqrt" argument -> sqrt
 abs : "\\abs" argument
     | "\\left"? "|" list "\\right"? "|"
 floor : "\\floor" argument
-      | "\\lfloor" list "\\rfloor"
+      | "\\left"? "\\lfloor" list "\\right"? "\\rfloor"
 ceil : "\\ceil" argument
-     | "\\lceil" list "\\rceil"
+     | "\\left"? "\\lceil" list "\\right"? "\\rceil"
 
-PAREN : "(" | "[" | "\\{" | ")" | "]" | "\\}"
-paren : PAREN
+PAREN : ("(" | "[" | "\\{" | ")" | "]" | "\\}")
+paren : ("\\left"|"\\right")? PAREN
 
 sum : "\\sum" "_" argument "^" argument
 prod : "\\prod" "_" argument "^" argument


### PR DESCRIPTION
Make it easier to copy-paste equations from-to LaTeX;

- Converting `×` to `\times` (without a trailing white-space) in copied text produced in incorrect LaTex in some cases (e.g. `2×x`).
- Allow the use of `*` for multiplication when pasting equations.
- Allow using `^` and `_` on single characters without braces  e.g. `x^2`