### PR TITLE
Add tooltip text to buttons

### DIFF
--- a/plots/colorpicker.py
+++ b/plots/colorpicker.py
@@ -17,6 +17,7 @@
 
 import gi
 from gi.repository import Gtk, GObject, Gdk
+from gettext import gettext as _
 
 class PopoverColorPicker(Gtk.Button):
     __gtype_name__ = "PopoverColorPicker"
@@ -27,6 +28,8 @@ class PopoverColorPicker(Gtk.Button):
 
     def __init__(self):
         super().__init__()
+
+        self.set_tooltip_text(_("Pick a color"))
 
         self.chooser = Gtk.ColorChooserWidget.new()
         self.chooser.show()

--- a/plots/ui/formula_box.ui
+++ b/plots/ui/formula_box.ui
@@ -40,6 +40,7 @@
               <object class="GtkButton" id="delete_button">
                 <property name="focusable">1</property>
                 <property name="receives-default">1</property>
+		<property name="tooltip-text" translatable="yes">Remove</property>
                 <child>
                   <object class="GtkImage">
                     <property name="halign">center</property>

--- a/plots/ui/formula_box.ui
+++ b/plots/ui/formula_box.ui
@@ -40,7 +40,7 @@
               <object class="GtkButton" id="delete_button">
                 <property name="focusable">1</property>
                 <property name="receives-default">1</property>
-		<property name="tooltip-text" translatable="yes">Remove</property>
+                <property name="tooltip-text" translatable="yes">Remove</property>
                 <child>
                   <object class="GtkImage">
                     <property name="halign">center</property>

--- a/plots/ui/plots.ui
+++ b/plots/ui/plots.ui
@@ -11,6 +11,7 @@
               <object class="GtkButton" id="add_equation">
                 <property name="focusable">1</property>
                 <property name="receives_default">1</property>
+				<property name="tooltip-text" translatable="yes">Add an equation</property>
                 <style>
                   <class name="flat"/>
                 </style>
@@ -33,6 +34,7 @@
                   <object class="GtkButton" id="undo">
                     <property name="focusable">1</property>
                     <property name="receives_default">1</property>
+					<property name="tooltip-text" translatable="yes">Undo</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -47,6 +49,7 @@
                   <object class="GtkButton" id="redo">
                     <property name="focusable">1</property>
                     <property name="receives_default">1</property>
+					<property name="tooltip-text" translatable="yes">Redo</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -67,6 +70,7 @@
             <property name="focus_on_click">0</property>
             <property name="receives_default">1</property>
             <property name="halign">end</property>
+			<property name="tooltip-text" translatable="yes">Open application menu</property>
             <child>
               <object class="GtkImage">
                 <property name="icon_name">open-menu-symbolic</property>
@@ -145,6 +149,7 @@
                               <object class="GtkButton" id="zoom_in">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
+								<property name="tooltip-text" translatable="yes">Zoom in</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-in-symbolic</property>
@@ -161,6 +166,7 @@
                               <object class="GtkButton" id="zoom_out">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
+								<property name="tooltip-text" translatable="yes">Zoom out</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-out-symbolic</property>
@@ -189,6 +195,7 @@
                                 <property name="receives_default">1</property>
                                 <property name="halign">end</property>
                                 <property name="valign">start</property>
+								<property name="tooltip-text" translatable="yes">Reset zoom and panning</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-original-symbolic</property>

--- a/plots/ui/plots.ui
+++ b/plots/ui/plots.ui
@@ -11,7 +11,7 @@
               <object class="GtkButton" id="add_equation">
                 <property name="focusable">1</property>
                 <property name="receives_default">1</property>
-				<property name="tooltip-text" translatable="yes">Add an equation</property>
+                <property name="tooltip-text" translatable="yes">Add an equation</property>
                 <style>
                   <class name="flat"/>
                 </style>
@@ -34,7 +34,7 @@
                   <object class="GtkButton" id="undo">
                     <property name="focusable">1</property>
                     <property name="receives_default">1</property>
-					<property name="tooltip-text" translatable="yes">Undo</property>
+                    <property name="tooltip-text" translatable="yes">Undo</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -49,7 +49,7 @@
                   <object class="GtkButton" id="redo">
                     <property name="focusable">1</property>
                     <property name="receives_default">1</property>
-					<property name="tooltip-text" translatable="yes">Redo</property>
+                    <property name="tooltip-text" translatable="yes">Redo</property>
                     <style>
                       <class name="flat"/>
                     </style>
@@ -70,7 +70,7 @@
             <property name="focus_on_click">0</property>
             <property name="receives_default">1</property>
             <property name="halign">end</property>
-			<property name="tooltip-text" translatable="yes">Open application menu</property>
+            <property name="tooltip-text" translatable="yes">Open application menu</property>
             <child>
               <object class="GtkImage">
                 <property name="icon_name">open-menu-symbolic</property>
@@ -149,7 +149,7 @@
                               <object class="GtkButton" id="zoom_in">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
-								<property name="tooltip-text" translatable="yes">Zoom in</property>
+                                <property name="tooltip-text" translatable="yes">Zoom in</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-in-symbolic</property>
@@ -166,7 +166,7 @@
                               <object class="GtkButton" id="zoom_out">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
-								<property name="tooltip-text" translatable="yes">Zoom out</property>
+                                <property name="tooltip-text" translatable="yes">Zoom out</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-out-symbolic</property>
@@ -195,7 +195,7 @@
                                 <property name="receives_default">1</property>
                                 <property name="halign">end</property>
                                 <property name="valign">start</property>
-								<property name="tooltip-text" translatable="yes">Reset zoom and panning</property>
+                                <property name="tooltip-text" translatable="yes">Reset zoom and panning</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-original-symbolic</property>


### PR DESCRIPTION
This PR improves the app's accessibility by adding tooltip text to buttons where it make sense.

Before:
![before](https://user-images.githubusercontent.com/31619874/192217226-db224381-280a-44c7-9923-5d6825f1cc32.png)

After:
![before](https://user-images.githubusercontent.com/31619874/192217382-2968f01c-890b-4ec4-9d62-0b141f26c1dd.png)

---

P.S.: This will add translatable text to the app.
