### PR TITLE
add grid opacity controls

### DIFF
--- a/plots/preferences.py
+++ b/plots/preferences.py
@@ -42,6 +42,7 @@ class Preferences(GObject.GObject):
         "rendering": {
             "line_thickness": 2.0,
             "samples": 32,
+            "grid_opacity": .5,
         }
     }
     CONFIG_DIR = "plots"
@@ -95,6 +96,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     line_thickness_scale = Gtk.Template.Child()
     samples_scale = Gtk.Template.Child()
+    grid_opacity = Gtk.Template.Child()
 
     def __init__(self, prefs, parent_window):
         super().__init__()
@@ -113,7 +115,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.samples_scale.set_digits(0)
         self.samples_scale.set_increments(1, 10)
 
+        self.grid_opacity.set_range(0, 1)
+        self.grid_opacity.set_value(prefs["rendering"]["grid_opacity"])
+        self.grid_opacity.set_increments(0.5, 3)
+
     def delete_cb(self, window):
         r = self.prefs["rendering"]
         r["line_thickness"] = self.line_thickness_scale.get_value()
         r["samples"] = int(self.samples_scale.get_value())
+        r["grid_opacity"] = self.grid_opacity.get_value()

--- a/plots/shaders/fragment.glsl
+++ b/plots/shaders/fragment.glsl
@@ -29,6 +29,7 @@ uniform float samples;
 uniform float line_thickness;
 uniform vec3 fg_color;
 uniform vec3 bg_color;
+uniform float grid_opacity;
 
 #define pi 3.141592653589793
 #define e 2.718281828459045
@@ -100,13 +101,13 @@ void main() {
     float jitter = .4;
 
     float axis_width = pixel_extent.x;
-    vec3 minor_color = mix(fg_color, bg_color, 0.6);
+    vec3 minor_color = mix(bg_color, fg_color, grid_opacity * 0.25);
     color = mix(minor_color, color, smoothstep(axis_width*.4, axis_width*.6, abs(zmod(graph_pos.x, minor_grid))));
     color = mix(minor_color, color, smoothstep(axis_width*.4, axis_width*.6, abs(zmod(graph_pos.y, minor_grid))));
-    vec3 major_color = mix(fg_color, bg_color, 0.4);
+    vec3 major_color = mix(bg_color, fg_color, grid_opacity * 0.5);
     color = mix(major_color, color, smoothstep(axis_width, axis_width*1.05, abs(zmod(graph_pos.x, major_grid))));
     color = mix(major_color, color, smoothstep(axis_width, axis_width*1.05, abs(zmod(graph_pos.y, major_grid))));
-    vec3 axis_color = fg_color;
+    vec3 axis_color = mix(bg_color, fg_color, grid_opacity);
     color = mix(axis_color, color, smoothstep(axis_width*.6, axis_width*.65, abs(graph_pos.x)));
     color = mix(axis_color, color, smoothstep(axis_width*.6, axis_width*.65, abs(graph_pos.y)));
 

--- a/plots/ui/preferences.ui
+++ b/plots/ui/preferences.ui
@@ -48,6 +48,21 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="title" translatable="yes">Grid opacity</property>
+                <property name="subtitle" translatable="yes">Reduce to subdue grid and axes</property>
+                <property name="use-underline">True</property>
+                <child>
+                  <object class="GtkScale" id="grid_opacity">
+                    <property name="draw-value">1</property>
+                    <property name="width-request">200</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Add a grid opacity slider to preferences to allow subduing the grid and axes.
Should hopefully improve readability of the plots (#99, #111).

![plots-dark-1](https://user-images.githubusercontent.com/489715/221086261-8666eb4b-53ab-4577-9230-6b4fd397a9a5.png)
![plots-dark-2](https://user-images.githubusercontent.com/489715/221086265-18325ad9-8fc5-46e4-95cb-dfdcc3ebdbce.png)
![plots-light-1](https://user-images.githubusercontent.com/489715/221086276-8ac0fb82-d228-4a12-b400-93551ef504b6.png)
![plots-light-2](https://user-images.githubusercontent.com/489715/221086281-f1d82808-0e69-461c-8dd1-6a0ce26c8f98.png)
