### PR TITLE
ui: HIG: tooltips now use header capitalization and primary menu use "Main Menu"

### DIFF
--- a/plots/ui/plots.ui
+++ b/plots/ui/plots.ui
@@ -70,7 +70,7 @@
             <property name="focus_on_click">0</property>
             <property name="receives_default">1</property>
             <property name="halign">end</property>
-            <property name="tooltip-text" translatable="yes">Menu</property>
+            <property name="tooltip-text" translatable="yes">Main Menu</property>
             <child>
               <object class="GtkImage">
                 <property name="icon_name">open-menu-symbolic</property>
@@ -149,7 +149,7 @@
                               <object class="GtkButton" id="zoom_in">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
-                                <property name="tooltip-text" translatable="yes">Zoom in</property>
+                                <property name="tooltip-text" translatable="yes">Zoom In</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-in-symbolic</property>
@@ -166,7 +166,7 @@
                               <object class="GtkButton" id="zoom_out">
                                 <property name="focusable">1</property>
                                 <property name="receives_default">1</property>
-                                <property name="tooltip-text" translatable="yes">Zoom out</property>
+                                <property name="tooltip-text" translatable="yes">Zoom Out</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-out-symbolic</property>
@@ -195,7 +195,7 @@
                                 <property name="receives_default">1</property>
                                 <property name="halign">end</property>
                                 <property name="valign">start</property>
-                                <property name="tooltip-text" translatable="yes">Reset zoom and panning</property>
+                                <property name="tooltip-text" translatable="yes">Reset Zoom and Panning</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="icon_name">zoom-original-symbolic</property>


### PR DESCRIPTION
Part of https://gitlab.gnome.org/GNOME/Initiatives/-/issues/40