### PR TITLE
Add shortcuts

### DIFF
--- a/plots/plots.py
+++ b/plots/plots.py
@@ -125,6 +125,12 @@ class Plots(Adw.Application):
         self.menu.append(_("About Plots"), "app.about")
         menu_button.set_menu_model(self.menu)
 
+        shortcuts_builder = Gtk.Builder()
+        shortcuts_builder.add_from_string(utils.read_ui_file("shortcuts.ui"))
+        shortcuts_dialog = shortcuts_builder.get_object("shortcuts_dialog")
+        self.window.set_help_overlay(shortcuts_dialog)
+        self.set_accels_for_action("win.show-help-overlay", ["<primary>question"])
+
         self.about_action = Gio.SimpleAction.new("about", None)
         self.about_action.connect("activate", self.about_cb)
         self.about_action.set_enabled(True)
@@ -141,6 +147,18 @@ class Plots(Adw.Application):
         export_action.set_enabled(True)
         self.add_action(export_action)
         self.set_accels_for_action("app.export", ["<primary>e"])
+
+        quit_action = Gio.SimpleAction.new("quit", None)
+        quit_action.connect("activate", self.quit_cb)
+        quit_action.set_enabled(True)
+        self.add_action(quit_action)
+        self.set_accels_for_action("app.quit", ["<primary>q"])
+
+        close_action = Gio.SimpleAction.new("close", None)
+        close_action.connect("activate", self.close_cb)
+        close_action.set_enabled(True)
+        self.add_action(close_action)
+        self.set_accels_for_action("app.close", ["<primary>w"])
 
         prefs_action = Gio.SimpleAction.new("preferences", None)
         prefs_action.connect("activate", self.prefs_cb)
@@ -271,6 +289,12 @@ class Plots(Adw.Application):
         about_window = builder.get_object("about_window")
         about_window.set_transient_for(self.window)
         about_window.present()
+
+    def quit_cb(self, action, param):
+        self.quit()
+
+    def close_cb(self, action, param):
+        self.window.close()
 
     def prefs_cb(self, action, param):
         self.prefs.show()

--- a/plots/ui/plots.ui
+++ b/plots/ui/plots.ui
@@ -70,6 +70,7 @@
             <property name="focus_on_click">0</property>
             <property name="receives_default">1</property>
             <property name="halign">end</property>
+            <property name="primary">True</property>
             <property name="tooltip-text" translatable="yes">Main Menu</property>
             <child>
               <object class="GtkImage">

--- a/plots/ui/shortcuts.ui
+++ b/plots/ui/shortcuts.ui
@@ -6,7 +6,54 @@
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
         <property name="max-height">10</property>
-	<child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcut window">General</property>
+	    <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Keyboard Shortcuts</property>
+                <property name="action-name">win.show-help-overlay</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Preferences</property>
+                <property name="action-name">app.preferences</property>
+              </object>
+            </child>
+	    <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Help</property>
+                <property name="action-name">app.help</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Main Menu</property>
+                <property name="accelerator">F10</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Close Window</property>
+                <property name="action-name">app.close</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Quit</property>
+                <property name="action-name">app.quit</property>
+              </object>
+            </child>
+	    <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Export Image</property>
+                <property name="action-name">app.export</property>
+              </object>
+            </child>
+          </object>
+	</child>
+        <child>
 	  <object class="GtkShortcutsGroup">
 	    <property name="title" translatable="yes" context="shortcut window">Zoom</property>
 	    <child>
@@ -29,41 +76,12 @@
 	    </child>
 	  </object>
         </child>
-        <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes" context="shortcut window">General</property>
-	    <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes">Keyboard Shortcuts</property>
-                <property name="action-name">win.show-help-overlay</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes">Preferences</property>
-                <property name="action-name">app.preferences</property>
-              </object>
-            </child>
-	    <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes">Help</property>
-                <property name="action-name">app.help</property>
-              </object>
-            </child>
-	    <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes">Export Image</property>
-                <property name="action-name">app.export</property>
-              </object>
-            </child>
-          </object>
-	</child>
 	<child>
 	  <object class="GtkShortcutsGroup">
 	    <property name="title" translatable="yes" context="shortcut window">Equations</property>
 	    <child>
 	      <object class="GtkShortcutsShortcut">
-		<property name="title" translatable="yes">Add an equation</property>
+		<property name="title" translatable="yes">Add an Equation</property>
 		<property name="action-name">app.add-equation</property>
               </object>
 	    </child>


### PR DESCRIPTION
- Add back shortcuts window that was added in #128 but partially deleted in #100
- Add keyboard shortcuts for 'Close Window' (Ctrl+W), 'Quit' (Ctrl+Q) and 'Main Menu' (F10) following the GNOME HIG ([link](https://developer.gnome.org/hig/reference/keyboard.html))
- List those shortcuts in shortcuts window
- Change order of shortcuts groups to avoid page break
- Fix capitalization following HIG ([link](https://developer.gnome.org/hig/guidelines/writing-style.html#header-capitalization))
![Screenshot_from_2023-08-28_12-04-14](https://github.com/alexhuntley/Plots/assets/132578586/6c163b7e-f8c2-490b-820d-5c045e952764)
Fixes #134