### PR TITLE
Show this app when searching for "plotter"

### DIFF
--- a/res/com.github.alexhuntley.Plots.metainfo.xml
+++ b/res/com.github.alexhuntley.Plots.metainfo.xml
@@ -168,6 +168,10 @@
 
   </description>
 
+  <keywords>
+    <keyword>plotter</keyword>
+  </keywords>
+
   <launchable type="desktop-id">com.github.alexhuntley.Plots.desktop</launchable>
 
   <screenshots>


### PR DESCRIPTION
When searching for "plotter" on Flathub, I only found KmPlot and some other apps, but in the back of my mind I knew there was a Gnome app. So I found this using a search engine. Would have been nice to find this plotter when searching for "plotter". I think adding "plotter" as a keyword to the appstream metainfo file would fix this?