### PR TITLE
Fix GLSL 3.30 is not supported & use GL renderer

### DIFF
--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -17,6 +17,10 @@
 
 from . import plots
 import sys
+import os
+
+os.environ["GDK_DEBUG"] = "gl-prefer-gl, gl-no-fractional"
+os.environ["GSK_RENDERER"] = "gl"
 
 def main():
     plots.Plots().run(sys.argv)


### PR DESCRIPTION
Fix: https://github.com/alexhuntley/Plots/issues/151

Vulkan and NGL renderer (available and default in GTK 4.14) are buggy and slow. See [#6411](https://gitlab.gnome.org/GNOME/gtk/-/issues/6411).