### PR TITLE
flatpak: Update to org.gnome.Platform version 47

### DIFF
--- a/com.github.alexhuntley.Plots.json
+++ b/com.github.alexhuntley.Plots.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.alexhuntley.Plots",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "plots",
   "finish-args": [

--- a/flatpak-requirements.txt
+++ b/flatpak-requirements.txt
@@ -1,6 +1,6 @@
-PyOpenGL == 3.1.6
-Jinja2 == 3.1.2
-numpy == 1.24.3
-lark == 1.1.5
-PyGLM == 2.5.7
-freetype-py == 2.3.0
+meson-python == 0.17.1
+PyOpenGL == 3.1.9
+numpy == 1.26.4
+lark == 1.2.2
+PyGLM == 2.7.3
+freetype-py == 2.5.1

--- a/python3-flatpak-requirements.json
+++ b/python3-flatpak-requirements.json
@@ -4,35 +4,40 @@
     "build-commands": [],
     "modules": [
         {
-            "name": "python3-PyOpenGL",
+            "name": "python3-meson-python",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyOpenGL==3.1.6\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python==0.17.1\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/5b/01/f8fd986bc7f456f1a925ee0239f0391838ade92cdb6e5b674ffb8b86cfd6/PyOpenGL-3.1.6.tar.gz",
-                    "sha256": "8ea6c8773927eda7405bffc6f5bb93be81569a7b05c8cac50cd94e969dce5e27"
+                    "url": "https://files.pythonhosted.org/packages/7d/ec/40c0ddd29ef4daa6689a2b9c5ced47d5b58fa54ae149b19e9a97f4979c8c/meson_python-0.17.1-py3-none-any.whl",
+                    "sha256": "30a75c52578ef14aff8392677b09c39346e0a24d2b2c6204b8ed30583c11269c"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
+                    "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e8/61/9dd3e68d2b6aa40a5fc678662919be3c3a7bf22cba5a6b4437619b77e156/pyproject_metadata-0.9.0-py3-none-any.whl",
+                    "sha256": "fc862aab066a2e87734333293b0af5845fe8ac6cb69c451a41551001e923be0b"
                 }
             ]
         },
         {
-            "name": "python3-Jinja2",
+            "name": "python3-PyOpenGL",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Jinja2==3.1.2\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyOpenGL==3.1.9\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/95/7e/68018b70268fb4a2a605e2be44ab7b4dd7ce7808adae6c5ef32e34f4b55a/MarkupSafe-2.1.2.tar.gz",
-                    "sha256": "abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz",
-                    "sha256": "31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"
+                    "url": "https://files.pythonhosted.org/packages/92/44/8634af40b0db528b5b37e901c0dc67321354880d251bf8965901d57693a5/PyOpenGL-3.1.9-py3-none-any.whl",
+                    "sha256": "15995fd3b0deb991376805da36137a4ae5aba6ddbb5e29ac1f35462d130a3f77"
                 }
             ]
         },
@@ -40,13 +45,13 @@
             "name": "python3-numpy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.24.3\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.26.4\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/2c/d4/590ae7df5044465cc9fa2db152ae12468694d62d952b1528ecff328ef7fc/numpy-1.24.3.tar.gz",
-                    "sha256": "ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155"
+                    "url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz",
+                    "sha256": "2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"
                 }
             ]
         },
@@ -54,13 +59,13 @@
             "name": "python3-lark",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"lark==1.1.5\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"lark==1.2.2\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a2/25/8e16de418fc83bb00dabaf8c7110bc45a90bf5481a70aa5f1668fcea73bc/lark-1.1.5.tar.gz",
-                    "sha256": "4b534eae1f9af5b4ea000bea95776350befe1981658eea3820a01c37e504bb4d"
+                    "url": "https://files.pythonhosted.org/packages/2d/00/d90b10b962b4277f5e64a78b6609968859ff86889f5b898c1a778c06ec00/lark-1.2.2-py3-none-any.whl",
+                    "sha256": "c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c"
                 }
             ]
         },
@@ -68,13 +73,13 @@
             "name": "python3-PyGLM",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyGLM==2.5.7\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyGLM==2.7.3\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a8/93/763c85038d18665b0ebab8cfb7a27fd14f38bdd5ad7e8d4b5aed4bf835bd/PyGLM-2.5.7.tar.gz",
-                    "sha256": "38fdff84e6416decffe1c5874632807d58b98c5508cca3579bb2f5332e099fd8"
+                    "url": "https://files.pythonhosted.org/packages/fe/a1/123daa472f20022785b18d6cdf6c71e30272aae03584a8ab861fa5fa01a5/pyglm-2.7.3.tar.gz",
+                    "sha256": "4ccb6c027622b948aebc501cd8c3c23690293115dc98108f8ed3b7fd533b398f"
                 }
             ]
         },
@@ -82,13 +87,13 @@
             "name": "python3-freetype-py",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"freetype-py==2.3.0\" --no-build-isolation --use-deprecated=legacy-resolver"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"freetype-py==2.5.1\" --no-build-isolation --use-deprecated=legacy-resolver"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/5d/77/341e6c61795a827390f394c7d5f682561c9fd79cc0b650937d3d5885e3cc/freetype-py-2.3.0.zip",
-                    "sha256": "f9b64ce3272a5c358dcee824800a32d70997fb872a0965a557adca20fce7a5d0"
+                    "url": "https://files.pythonhosted.org/packages/d0/9c/61ba17f846b922c2d6d101cc886b0e8fb597c109cedfcb39b8c5d2304b54/freetype-py-2.5.1.zip",
+                    "sha256": "cfe2686a174d0dd3d71a9d8ee9bf6a2c23f5872385cf8ce9f24af83d076e2fbd"
                 }
             ]
         }


### PR DESCRIPTION
* Added mesonpy to compile numpy.
* Removed Jinja2 as it's part of the platform
* Bumped dependency versions

I generated the `python3-flatpak-requirements.json` using:
```
flatpak-pip-generator --runtime='org.gnome.Sdk//47' --requirements-file=./flatpak-requirements.txt
```
Then manually added `--use-deprecated=legacy-resolver` for `freetype-py`

This suffers from https://github.com/alexhuntley/Plots/issues/151

Is the version on flathub generated from this repo or https://github.com/flathub/com.github.alexhuntley.Plots?